### PR TITLE
README onFailure parameter 누락 오류 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ ReactDOM.render(
     callbackUrl="http://127.0.0.1:3000/login"
     render={(props) => <div onClick={props.onClick}>Naver Login</div>}
     onSuccess={(naverUser) => console.log(naverUser)}
-    onFailure={() => console.error(result)}
+    onFailure={(result) => console.error(result)}
   />,
   document.getElementById('root')
 );


### PR DESCRIPTION
Line 29의 onFailure 값으로 주어진 함수의 반환값인 console.error(result)는 result parameter를 필요로 합니다.